### PR TITLE
update: depandabotのターゲットブランチをdevelopに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    target-branch: develop
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    target-branch: develop
 


### PR DESCRIPTION
## 概要
dependabotのPR作成先がmainになっていたので、developに変更

## 変更内容
- target-branchを設定
- 

## 動作確認
- [ ] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- [GitHub Dependabotのtarget-branchオプション指定時の動作を確認してみた | DevelopersIO](https://dev.classmethod.jp/articles/apply-github-dependabot-to-a-non-default-branch/)

## 備考
