### PR TITLE
feat: Headingコンポーネントを追加

### DIFF
--- a/astro/src/components/ui/Heading/index.astro
+++ b/astro/src/components/ui/Heading/index.astro
@@ -10,40 +10,30 @@ const Tag = as;
 ---
 
 <Tag class={className} {...rest}>
+  <span aria-hidden="true" class="heading-prefix">  
+    {as === "h1" && "#"}  
+    {as === "h2" && "##"}  
+    {as === "h3" && "###"}  
+    {as === "h4" && "####"}  
+  </span>  
   <slot />
 </Tag>
 
 <style>
   h1 {
     @apply text-4xl font-bold text-gray-800;
-    
-    &::before {
-      content: '#';
-      @apply text-blue-500 mr-2;
-    }
   }
   h2 {
     @apply text-3xl font-bold text-gray-800;
-
-    &::before {
-      content: '##';
-      @apply text-blue-500 mr-2;
-    }
   }
   h3 {
     @apply text-2xl font-bold text-gray-800;
-
-    &::before {
-      content: '###';
-      @apply text-blue-500 mr-2;
-    }
   }
   h4 {
     @apply text-xl font-bold text-gray-800;
+  }
 
-    &::before {
-      content: '####';
-      @apply text-blue-500 mr-2;
-    }
+  .heading-prefix {
+    @apply text-blue-500 mr-2;
   }
 </style>


### PR DESCRIPTION
## 概要
各ページやセクションで共通利用できる`Heading`コンポーネントを追加し、それに伴うlint修正・スタイル微調整を行いました。

## 変更内容
- `Heading`コンポーネントを実装
- lintエラーの修正およびスタイルの微調整を実施

## 動作確認
- [x] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- なし

## 備考
スクリーンショット
<img width="221" height="147" alt="image" src="https://github.com/user-attachments/assets/ef40beef-bbe1-4c52-abc8-fe1036916de9" />
