### PR TITLE
style: モバイル画面でも表示が崩れないように横幅を修正

### DIFF
--- a/astro/src/components/pages/home/ActivityDetails/mobile.astro
+++ b/astro/src/components/pages/home/ActivityDetails/mobile.astro
@@ -61,7 +61,7 @@ const { activityDetails } = props;
 
 <style>
   .activity-detail {
-    @apply flex flex-col border-2 border-gray-500 pb-4 rounded-md p-4 bg-white/50 gap-4 w-[calc(100%-100px)] mx-auto mb-10;
+    @apply flex flex-col border-2 border-gray-500 pb-4 rounded-md p-4 bg-white/50 gap-4 w-[calc(100%-10px)] mx-auto mb-10;
     min-height: 28rem;
   }
 </style>


### PR DESCRIPTION
## 概要
活動詳細セクションのモバイル表示で横幅が崩れる問題を修正しました。

## 変更内容
- `ActivityDetails/mobile.astro` の `.activity-detail` の横幅を `w-[calc(100%-100px)]` から `w-[calc(100%-10px)]` に変更
- モバイル画面でもコンテンツが適切に収まるように調整

## 動作確認
- [x] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考
before
<img width="319" height="684" alt="image" src="https://github.com/user-attachments/assets/ac777418-93b1-4ec7-8b15-c26324b1e7f9" />


after
<img width="315" height="681" alt="image" src="https://github.com/user-attachments/assets/f282fe27-bbda-4bb0-bf0d-d2aa0464baa7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * モバイルデバイスのアクティビティ詳細画面におけるコンテンツの表示領域の幅を調整しました。これにより、ユーザーインターフェースの利用可能なスペースが拡大され、より効果的にコンテンツが表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->