### PR TITLE
Feature/add blog author

### DIFF
--- a/astro/src/components/pages/BlogArticle/index.astro
+++ b/astro/src/components/pages/BlogArticle/index.astro
@@ -1,12 +1,12 @@
 ---
 import Image from "astro/components/Image.astro";
 import { Icon } from "astro-icon/components";
+import dayjs from "dayjs";
 import Heading from "@/components/ui/Heading/index.astro";
 import MarkdownContainer from "@/components/ui/MarkdownContainer/index.astro";
 import Tags from "@/components/ui/TagList/index.astro";
 import { PATH } from "@/constants";
 import type { BlogItem } from "@/types";
-import dayjs from "dayjs";
 
 type Props = {
 	blog: BlogItem;
@@ -14,8 +14,7 @@ type Props = {
 
 const { blog } = Astro.props as Props;
 
-const { title, description, thumbnail, tags, content, published_at, author } =
-	blog;
+const { title, description, thumbnail, tags, content, published_at, author } = blog;
 ---
 
 {


### PR DESCRIPTION
## 概要
記事の詳細ページに著者と日付を表示

## 変更内容
- 記事の詳細ページに著者と日付を表示しました！！！
- 

## 動作確認
- [x] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考
<img width="708" height="343" alt="スクリーンショット 2026-02-11 17 18 34" src="https://github.com/user-attachments/assets/8795a54a-250f-4b2d-8076-85146587242e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブログ記事に公開日（YYYY-MM-DD形式）と著者情報を表示するようにしました。
  * 著者名をクリックすると、その著者の記事でフィルタリングできるようになりました。

* **改善**
  * ブログ記事のヘッダーレイアウトを整理し、日付と著者情報を説明とタグの上に配置しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->