### PR TITLE
fix: タイムゾーンを東京に設定

### DIFF
--- a/cms/config/application.rb
+++ b/cms/config/application.rb
@@ -21,7 +21,7 @@ module Cms
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## 概要
タイムゾーンを東京に設定しました

## 変更内容
- 東京に設定
- 

## 動作確認
- [x] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定変更**
  * アプリケーションのデフォルトタイムゾーンを東京に更新しました。この変更により、タイムスタンプおよび時間関連の機能が新しいタイムゾーンに基づいて動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->