### PR TITLE
Fix/header image

### DIFF
--- a/astro/src/components/pages/BlogArticle/index.astro
+++ b/astro/src/components/pages/BlogArticle/index.astro
@@ -14,13 +14,13 @@ type Props = {
 
 const { blog } = Astro.props as Props;
 
-const { title, description, thumbnail, tags, content, published_at, author } = blog;
+const { title, description, header_image_url, tags, content, published_at, author } = blog;
 ---
 
 {
-	thumbnail && (
+	header_image_url && (
 		<Image
-			src={thumbnail}
+			src={header_image_url}
 			alt={title}
 			width={100}
 			height={100}

--- a/astro/src/components/ui/BlogCard/Thumbnail.astro
+++ b/astro/src/components/ui/BlogCard/Thumbnail.astro
@@ -13,7 +13,7 @@ const { src, title } = Astro.props as Props;
 
 {
 	(
-		<Image
+		<img
 			src={src ?? PATH.IMAGES("default-thumbnail.jpg")}
 			alt={`${title}のサムネイル`}
 			width={720}

--- a/astro/src/components/ui/BlogCard/index.astro
+++ b/astro/src/components/ui/BlogCard/index.astro
@@ -14,7 +14,7 @@ const { blog } = Astro.props as Props;
 ---
 
 <div class={blogCardStyles.container}>
-  <Thumbnail src={blog.thumbnail} title={blog.title} />
+  <Thumbnail src={blog.header_image_url} title={blog.title} />
   <div>
     <p class={blogCardStyles.publishedAt}>
       {dayjs(blog.published_at).format("YYYY-MM-DD")}

--- a/astro/src/components/ui/BlogCard/index.tsx
+++ b/astro/src/components/ui/BlogCard/index.tsx
@@ -12,7 +12,7 @@ export default function BlogCard({ blog }: Props) {
 	return (
 		<div className={blogCardStyles.container}>
 			<img
-				src={blog.thumbnail ?? PATH.IMAGES("default-thumbnail.jpg")}
+				src={blog.header_image_url ?? PATH.IMAGES("default-thumbnail.jpg")}
 				alt={blog.title}
 				className={blogCardStyles.thumbnail}
 			/>

--- a/astro/src/hooks/blogsApi.ts
+++ b/astro/src/hooks/blogsApi.ts
@@ -38,7 +38,7 @@ export type SearchPost = {
 	author: string;
 	published_at: string;
 	tags: string[];
-	thumbnail: string;
+	header_image_url: string;
 };
 
 export type SearchApiResponse = {
@@ -68,7 +68,7 @@ function transformApiResponseToBlogItem(
 		content: post.content || post.description || "",
 		description: post.description ?? post.content,
 		author: post.author,
-		thumbnail: post.thumbnail ?? undefined,
+		header_image_url: post.header_image_url ?? undefined,
 		published_at: post.published_at,
 		tags: post.tags,
 	};

--- a/astro/src/scripts/fetchBlogsDuringBuild.ts
+++ b/astro/src/scripts/fetchBlogsDuringBuild.ts
@@ -12,7 +12,7 @@ interface Blog {
 	author: string;
 	published_at: string;
 	tags: string[];
-	thumbnail: string;
+	header_image_url: string;
 	created_at: string;
 	updated_at: string;
 }
@@ -40,7 +40,7 @@ function toFrontmatter(blog: Blog): string {
 	const description = blog.description ?? "";
 	const publishedAt = blog.published_at;
 	const tags = Array.isArray(blog.tags) ? blog.tags : [];
-	const thumbnail = blog.thumbnail ?? "";
+	const headerImageUrl = blog.header_image_url ?? "";
 	const lines = [
 		"---",
 		`title: ${escapeYamlString(title)}`,
@@ -49,7 +49,7 @@ function toFrontmatter(blog: Blog): string {
 		`published_at: ${escapeYamlString(publishedAt)}`,
 		"tags:",
 		...tags.map((t) => `  - ${escapeYamlString(t)}`),
-		`thumbnail: ${escapeYamlString(thumbnail)}`,
+		`header_image_url: ${escapeYamlString(headerImageUrl)}`,
 		"",
 		"---",
 		"",

--- a/astro/src/types/blogTag.ts
+++ b/astro/src/types/blogTag.ts
@@ -10,7 +10,7 @@ export type BlogItem = {
 	content: string;
 	description?: string;
 	author: string;
-	thumbnail?: string;
+	header_image_url?: string;
 	published_at: string;
 	tags: string[];
 };

--- a/cms/app/models/blog.rb
+++ b/cms/app/models/blog.rb
@@ -28,7 +28,7 @@ class Blog < ApplicationRecord
 
   def header_image_url
     if header_image.attached?
-      Rails.application.routes.url_helpers.rails_blob_url(header_image, only_path: true)
+      Rails.application.routes.url_helpers.rails_blob_url(header_image)
     else
       nil
     end

--- a/cms/config/environments/development.rb
+++ b/cms/config/environments/development.rb
@@ -40,6 +40,9 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Active Storage がフル URL を生成するために必要
+  Rails.application.routes.default_url_options = { host: "localhost", port: 3000 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/cms/config/environments/production.rb
+++ b/cms/config/environments/production.rb
@@ -60,6 +60,9 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
 
+  # Set host for url_helpers (e.g. rails_blob_url) to generate absolute URLs.
+  Rails.application.routes.default_url_options = { host: "cms.fukupro.club" }
+
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
   #   user_name: Rails.application.credentials.dig(:smtp, :user_name),

--- a/cms/config/environments/test.rb
+++ b/cms/config/environments/test.rb
@@ -39,7 +39,10 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
 
-  # Print deprecation notices to the stderr.
+  # Set host for url_helpers (e.g. rails_blob_url) to generate absolute URLs.
+  Rails.application.routes.default_url_options = { host: "example.com" }
+
+  # Print deprecation notices. to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.

--- a/cms/config/initializers/cors.rb
+++ b/cms/config/initializers/cors.rb
@@ -6,5 +6,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       headers: :any,
       methods: [ :get, :options ],
       credentials: false
+
+    resource "/rails/active_storage/*",
+      headers: :any,
+      methods: [ :get, :options ],
+      credentials: false
   end
 end

--- a/terraform/cms.tf
+++ b/terraform/cms.tf
@@ -72,8 +72,8 @@ resource "sakuracloud_packet_filter_rules" "rails" {
 # サーバーの定義
 resource "sakuracloud_server" "rails_app" {
   name   = "rails-server"
-  core   = 4
-  memory = 8
+  core   = 2
+  memory = 2
   disks  = [sakuracloud_disk.boot.id]
 
   network_interface {


### PR DESCRIPTION
## 概要
header_image_urlにRailsの相対パスが渡っていた問題を修正

## 変更内容
- header_image_urlの相対パスをURLに変更
- astroのthumbnailをheader_image_urlに変更
- terraformのcoreとmemoryを2に変更

## 動作確認
- [x] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ブログ記事の画像フィールドを「header_image_url」に切替し、カード・一覧・記事ヘッダーで反映。

* **改善**
  * 生成される画像URLを絶対パスに変更（開発・テスト・本番環境のデフォルトURL設定を追加）。
  * Active Storage用のCORS設定を追加し画像取得を許可。
  * サーバーのCPU/メモリ構成を調整。

* **リファクタ**
  * サムネイル表示に関わるレンダリングを軽量化（アセット表示方式を単純化）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->