### PR TITLE
fix: 参照が0のタグをフィルタリング

### DIFF
--- a/cms/app/controllers/api/tags_controller.rb
+++ b/cms/app/controllers/api/tags_controller.rb
@@ -5,6 +5,7 @@ module Api
                         .left_joins(:blogs)
                         .group("tags.id", "tags.name")
                         .select("tags.id, tags.name, COUNT(blogs.id) AS blogs_count")
+                        .having("COUNT(blogs.id) > 0")
                         .order("blogs_count DESC")
 
       sorted_tags = tags_with_count.map do |tag|


### PR DESCRIPTION
## 概要
参照が0個のタグをフィルタリングして返さないように変更

## 変更内容
- 
- 

## 動作確認
- [ ] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* タグAPI機能を改善しました。ブログに関連するタグのみが検索結果に表示されるようになりました。これにより、ユーザーはより関連性の高い正確なタグ検索結果を得られるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->