### PR TITLE
feat: 検索APIで今日作られた記事を返さないようにフィルタリング

### DIFF
--- a/cms/app/controllers/api/blogs_controller.rb
+++ b/cms/app/controllers/api/blogs_controller.rb
@@ -11,6 +11,7 @@ module Api
 
     def search
       blogs = filter_by_published_at(Blog.includes(:tags, header_image_attachment: :blob).order(published_at: :desc))
+      blogs = exclude_created_today(blogs)
 
       if params[:q].present?
         params[:q].split.first(MAX_SEARCH_TERMS).each do |term|
@@ -32,6 +33,10 @@ module Api
 
     def filter_by_published_at(scope)
       scope.where("published_at <= ?", Time.zone.now)
+    end
+
+    def exclude_created_today(scope)
+      scope.where("created_at < ?", Time.zone.now.beginning_of_day)
     end
 
     def paginate(scope)


### PR DESCRIPTION
## 概要
Astroのデプロイによって生成される記事と検索APIの記事にラグがあった。
これは、記事一覧画面にはあるが、遷移すると404になるというバグを発生させていた。
そのため、今日作られた記事をフィルタリングして対策する

## 変更内容
- exclude_created_todayを追加し、今日作られた記事を返さないようにフィルタリング
- 

## 動作確認
- [x] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ブログ検索

* **新機能**
  * 検索結果から当日作成されたブログを除外するフィルタ機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->