### PR TITLE
fix: ヘッダー画像を表示するように修正

### DIFF
--- a/astro/src/components/pages/BlogArticle/index.astro
+++ b/astro/src/components/pages/BlogArticle/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from "astro:assets";
 import { Icon } from "astro-icon/components";
 import dayjs from "dayjs";
 import Heading from "@/components/ui/Heading/index.astro";

--- a/astro/src/components/pages/BlogArticle/index.astro
+++ b/astro/src/components/pages/BlogArticle/index.astro
@@ -14,47 +14,52 @@ type Props = {
 
 const { blog } = Astro.props as Props;
 
-const { title, description, header_image_url, tags, content, published_at, author } = blog;
+const {
+	title,
+	description,
+	header_image_url,
+	tags,
+	content,
+	published_at,
+	author,
+} = blog;
 ---
 
-{
-	header_image_url && (
-		<Image
-			src={header_image_url}
-			alt={title}
-			width={100}
-			height={100}
-			class="thumbnail"
-		/>
-	)
-}
 <article class="blog-article">
-	<div class="blog-header">
-		<nav>
-			<a href={PATH.BLOGS} class="back-link">
-				<Icon name="ri:arrow-left-s-line" />
-				<span>戻る</span>
-			</a>
-		</nav>
-		<Heading as="h1">{title}</Heading>
-		<div
-			class="flex items-center gap-2 justify-between text-base text-gray-500"
-		>
-			<p>
-				{dayjs(published_at).format("YYYY-MM-DD")}
-			</p>
-			<a
-				href={`${PATH.BLOGS}?q=author:${encodeURIComponent(author)}`}
-				class="hover:underline"
-			>
-				{author}
-			</a>
-		</div>
-		{description && <p class="description">{description}</p>}
-		<Tags tags={tags} />
-	</div>
+	{
+		header_image_url && (
+			<img src={header_image_url} alt={title} class="thumbnail" />
+		)
+	}
 
-	<MarkdownContainer markdown={content} />
+	<div class="blog-container">
+		<div class="blog-header">
+			<nav>
+				<a href={PATH.BLOGS} class="back-link">
+					<Icon name="ri:arrow-left-s-line" />
+					<span>戻る</span>
+				</a>
+			</nav>
+			<Heading as="h1">{title}</Heading>
+			<div
+				class="flex items-center gap-2 justify-between text-base text-gray-500"
+			>
+				<p>
+					{dayjs(published_at).format("YYYY-MM-DD")}
+				</p>
+				<a
+					href={`${PATH.BLOGS}?q=author:${encodeURIComponent(author)}`}
+					class="hover:underline"
+				>
+					{author}
+				</a>
+			</div>
+			{description && <p class="description">{description}</p>}
+			<Tags tags={tags} />
+		</div>
+
+		<MarkdownContainer markdown={content} />
+	</div>
 </article>
 
 <style>
@@ -63,7 +68,6 @@ const { title, description, header_image_url, tags, content, published_at, autho
 		max-width: 720px;
 		min-height: 90vh;
 		margin: 0 auto;
-		padding: 1rem 2rem;
 		line-height: 1.8;
 	}
 
@@ -92,5 +96,9 @@ const { title, description, header_image_url, tags, content, published_at, autho
 		max-height: 180px;
 		object-fit: cover;
 		box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
+	}
+
+	.blog-container {
+		padding: 1rem 2rem;
 	}
 </style>

--- a/astro/src/components/pages/BlogArticle/index.astro
+++ b/astro/src/components/pages/BlogArticle/index.astro
@@ -14,15 +14,7 @@ type Props = {
 
 const { blog } = Astro.props as Props;
 
-const {
-	title,
-	description,
-	header_image_url,
-	tags,
-	content,
-	published_at,
-	author,
-} = blog;
+const { title, description, header_image_url, tags, content, published_at, author } = blog;
 ---
 
 <article class="blog-article">

--- a/astro/src/pages/blogs/[blog_id].astro
+++ b/astro/src/pages/blogs/[blog_id].astro
@@ -8,7 +8,7 @@ import type { BlogItem } from "@/types";
 type MarkdownModule = MarkdownInstance<{
 	title: string;
 	description?: string;
-	thumbnail?: string;
+	header_image_url?: string;
 	tags: string[];
 	author: string;
 	published_at: string;
@@ -52,7 +52,7 @@ const blog: BlogItem = {
 	id: blog_id,
 	title: frontmatter.title,
 	description: frontmatter.description ?? "",
-	thumbnail: frontmatter.thumbnail,
+	header_image_url: frontmatter.header_image_url,
 	tags: frontmatter.tags,
 	content: rawContent,
 	author: frontmatter.author,
@@ -64,7 +64,7 @@ const blog: BlogItem = {
   title={`${frontmatter.title} | 福プロ`}
   description={frontmatter.description ?? "福プロ（福山大学学友会プログラミングサークル）の記事です。"}
   author={frontmatter.author ?? "福プロ"}
-  thumbnail={frontmatter.thumbnail ?? PATH.IMAGES("default-thumbnail.jpg")}
+  thumbnail={frontmatter.header_image_url ?? PATH.IMAGES("default-thumbnail.jpg")}
   tags={frontmatter.tags}
 >
   <BlogArticle blog={blog} />


### PR DESCRIPTION
## 概要
ヘッダー画像が出ていなかったので修正を行いました

## 変更内容
- マークダウンのデータ構造に合わせるように修正
- Image -> imgタグ
- BlogArticleのレイアウト修正

## 動作確認
- [x] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ブログ記事のヘッダー表示を見直し、画像の出力を簡素化して表示を安定化
  * 記事コンテンツを新しい内側コンテナにまとめ、全体のレイアウトとパディングを調整
  * ヘッダー内に戻るリンク、タイトル、公開日・著者のメタデータ行を再配置し著者をリンク化
  * 説明文とタグを条件付きでヘッダー内に表示するよう整理
  * 画像フィールド名の内部命名規則を統一
<!-- end of auto-generated comment: release notes by coderabbit.ai -->