### PR TITLE
fix: 記事一覧のレイアウトを最新記事と合わせる

### DIFF
--- a/astro/src/components/pages/Blogs/BlogListWithPagination.tsx
+++ b/astro/src/components/pages/Blogs/BlogListWithPagination.tsx
@@ -27,7 +27,7 @@ export default function BlogListWithPagination({
 			) : blogs.length === 0 ? (
 				<NoDataView />
 			) : (
-				<div className="grid grid-cols-1 gap-4 py-3 md:grid-cols-3">
+				<div className="grid sm:grid-cols-3 grid-cols-1 gap-4">
 					{blogs.map((blog: BlogItem) => (
 						<BlogCard key={blog.id} blog={blog} />
 					))}


### PR DESCRIPTION
## 概要
記事一覧ページのBlogCardのレイアウトが崩れていたため修正

## 変更内容
- BlogCardの親要素のスタイルを修正
- 

## 動作確認
- [x] ローカルで動作確認した
- [ ] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ブログリストのレスポンシブレイアウトを改善しました。小さい画面サイズでも3列グリッド表示が有効になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->