### PR TITLE
Markdownでリンクを踏むと遷移してしまう問題を修正

### DIFF
--- a/cms/app/helpers/application_helper.rb
+++ b/cms/app/helpers/application_helper.rb
@@ -1,8 +1,20 @@
 module ApplicationHelper
+  # リンクを新しいタブで開くカスタムレンダラー
+  class ExternalLinkRenderer < Redcarpet::Render::HTML
+    def link(link, title, content)
+      title_attr = title ? %( title="#{title}") : ""
+      %(<a href="#{link}"#{title_attr} target="_blank" rel="noopener noreferrer">#{content}</a>)
+    end
+
+    def autolink(link, link_type)
+      %(<a href="#{link}" target="_blank" rel="noopener noreferrer">#{link}</a>)
+    end
+  end
+
   def markdown(text)
     return "" if text.blank?
 
-    renderer = Redcarpet::Render::HTML.new(
+    renderer = ExternalLinkRenderer.new(
       hard_wrap: true,
       filter_html: false
     )

--- a/cms/app/helpers/application_helper.rb
+++ b/cms/app/helpers/application_helper.rb
@@ -1,13 +1,25 @@
 module ApplicationHelper
   # リンクを新しいタブで開くカスタムレンダラー
   class ExternalLinkRenderer < Redcarpet::Render::HTML
+    include ERB::Util
+
     def link(link, title, content)
-      title_attr = title ? %( title="#{title}") : ""
-      %(<a href="#{link}"#{title_attr} target="_blank" rel="noopener noreferrer">#{content}</a>)
+      return html_escape(content) unless safe_url?(link)
+
+      href = html_escape(link)
+      title_attr = title ? %( title="#{html_escape(title)}") : ""
+      %(<a href="#{href}"#{title_attr} target="_blank" rel="noopener noreferrer">#{content}</a>)
     end
 
-    def autolink(link, link_type)
-      %(<a href="#{link}" target="_blank" rel="noopener noreferrer">#{link}</a>)
+    def autolink(link, _link_type)
+      escaped = html_escape(link)
+      %(<a href="#{escaped}" target="_blank" rel="noopener noreferrer">#{escaped}</a>)
+    end
+
+    private
+
+    def safe_url?(url)
+      url.match?(%r{\Ahttps?://}i) || url.start_with?("/", "#")
     end
   end
 


### PR DESCRIPTION
## 概要
Markdownでリンクを踏むと遷移してしまう問題を修正

## 変更内容
- Markdownでリンクを踏むと別タブに移動するように修正
- XSS対策を追加

## 動作確認
- [x] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Markdown内の外部リンクが新しいタブで開くようになりました。セキュリティ属性が自動的に付与され、より安全なリンク操作が実現されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->