### PR TITLE
chore: deploy-astro.ymlにmainブランチの参照を追加

### DIFF
--- a/.github/workflows/deploy-astro.yml
+++ b/.github/workflows/deploy-astro.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: main
       - name: Install, build, and upload your site
         uses: withastro/action@v5
         with:


### PR DESCRIPTION
## 概要
現状だとデフォルトブランチがdevelopであるため、スケジュールによるデプロイ時にdevelopを指定しまい、デプロイが失敗していた。
よって、デプロイ時にmainブランチを参照するように修正する。

## 変更内容
- deploy-astro.ymlにmainブランチ参照の設定を追加
- 

## 動作確認
- [ ] ローカルで動作確認した
- [x] CIが通ることを確認した
- [ ] 影響範囲を確認した（あれば）

## 関連リンク
- 

## 備考



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **雑務**
  * デプロイメントワークフローの信頼性向上のため、ビルドプロセスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->